### PR TITLE
Fix Mailing List Last name checker

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -111,8 +111,8 @@ class MLRequest
   end
 
   def valid?
-    @first_name =~ /\A[a-zA-Z]+\Z/ &&
-    @last_name  =~ /\A[a-zA-Z]+\Z/ &&
+    @first_name =~ /\A[a-zA-Z. ]+\Z/ &&
+    @last_name  =~ /\A[a-zA-Z. ]+\Z/ &&
     !@email.empty? &&
     LISTS.include?(@list) && ACTIONS.include?(@action)
   end


### PR DESCRIPTION
Hi All, 

I tried to register for the ruby mailing list and noticed that there was a regex that filters for name validity. I've updated the regular expression so it allows for person's who have spaces in their names or periods. Now I (Earl St Sauver) and any number of other people (The Mc. *'s of the world) can register. 

~Earl
